### PR TITLE
Fix flaky ClusterStatsIT.testClusterStatsWithMappingsAndAnalysisStatsIndexMetricsFilter

### DIFF
--- a/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -740,7 +740,7 @@ public class ClusterStatsIT extends OpenSearchIntegTestCase {
         ensureGreen();
 
         client().admin().indices().prepareCreate("test1").setMapping("{\"properties\":{\"foo\":{\"type\": \"keyword\"}}}").get();
-        IndexRequest indexRequest = new IndexRequest("test1").id("doc_id").source(Map.of("test_type", "metrics_filter"));
+        IndexRequest indexRequest = new IndexRequest("test1").id("doc_id").source(Map.of("foo", "metrics_filter"));
         client().index(indexRequest);
 
         ClusterStatsRequestBuilder clusterStatsRequestBuilder = client().admin()


### PR DESCRIPTION
## Description

Fixes flaky test `ClusterStatsIT.testClusterStatsWithMappingsAndAnalysisStatsIndexMetricsFilter` reported in https://github.com/opensearch-project/OpenSearch/issues/21358.

### Root Cause

The test creates an index with an explicit mapping containing only a `foo` keyword field, then indexes a document with `Map.of("test_type", "metrics_filter")`. Since `test_type` is not in the explicit mapping, dynamic mapping adds `text` and `keyword` field types for it. The test then fetches cluster stats twice (with different metric filters) and asserts the mappings are equal. However, the first request may execute before the dynamic mapping update is propagated, seeing only 1 keyword field, while the second request sees the updated mapping with 2 keyword fields and 1 text field.

From the Jenkins failure:
```
expected: keyword count=1
actual:   keyword count=2, text count=1
```

### Fix

Use the already-mapped `foo` field in the indexed document instead of introducing a new dynamically-mapped `test_type` field. This ensures no dynamic mapping changes occur between the two cluster stats requests, eliminating the race condition.

### Testing

- Verified the test passes consistently with `--tests.iters=10` locally.